### PR TITLE
chore: set fixed apollo version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "316f118566f42b90cb90987b3efd2d60b2908d2661ebc8a2bd0711f8e0300149",
+  "originHash" : "9845a792f088bf8bae0bc64199f1f1cd7be88ffc413e314c3aee537de4a2cced",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "0d140a1933cb9cbafb2c6861b5d358d422d5f21e",
-        "version" : "1.16.0"
+        "revision" : "e98e9d3b398b6005149074d51b097e31aaa44f63",
+        "version" : "1.17.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/Bip39.swift.git", from: "0.1.1"),
         .package(url: "https://github.com/auth0/JWTDecode.swift", from: "3.1.0"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
-        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0")
+        .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.17.0")
     ],
     targets: [
         .target(

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/Bip39.swift.git", from: "0.1.1"),
         .package(url: "https://github.com/auth0/JWTDecode.swift", from: "3.1.0"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
-        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0")
+        .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.17.0")
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/Bip39.swift.git", from: "0.1.1"),
         .package(url: "https://github.com/auth0/JWTDecode.swift", from: "3.1.0"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
-        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0")
+        .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.17.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
### Description:

In the new version of Apollo, there is a breaking change. If you could confirm, the library is currently not working. This PR reverts to the previous version (until the necessary changes can be made to use version 1.18.0).

> [!NOTE]
> **Apollo last version:** https://github.com/apollographql/apollo-ios/releases/tag/1.18.0